### PR TITLE
Update entrypoint.sh

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -18,6 +18,8 @@ password_change() {
     echo "ran password change"
 }
 
+touch startup.log
+
 server_startup &
 password_change
 wait


### PR DESCRIPTION
Sometimes the script looks for startup.log file that is not created and crashes. This makes the docker to stay in starting state and hence kills itself after a while.
By adding this one line `touch startup.log` before running the scripts we make sure that the file exists before we get into trying to read the file.